### PR TITLE
Avoid pushing default dog identifier to TOPO server.

### DIFF
--- a/TrackerConsole/Program.cs
+++ b/TrackerConsole/Program.cs
@@ -23,6 +23,7 @@ namespace TrackerConsole
   class Program
   {
     static string callsign = null;
+    const string DefaultIdentifier = "Dog";
 
     static void Main(string[] args)
     {
@@ -159,18 +160,22 @@ namespace TrackerConsole
         try
         {
           string identifier = entry.Identifier;
-          if (!string.IsNullOrWhiteSpace(callsign)) identifier = callsign + "-" + identifier;
+          // Don't push a server update if a collar was just added to the BaseStation device.
+          if (!string.IsNullOrEmpty(identifier) && !string.Equals(identifier, DefaultIdentifier, StringComparison.InvariantCultureIgnoreCase))
+          {
+            if (!string.IsNullOrWhiteSpace(callsign)) identifier = callsign + "-" + identifier;
 
-          await _web.GetAsync($"{_server}/rest/location/update/position?lat={entry.Position.Latitude}&lng={entry.Position.Longitude}&id=FLEET:{identifier}");
+              await _web.GetAsync($"{_server}/rest/location/update/position?lat={entry.Position.Latitude}&lng={entry.Position.Longitude}&id=FLEET:{identifier}");
+          }
         }
         catch (HttpRequestException ex)
 
         {
-          LogException(ex.InnerException.Message);
+            LogException(ex.InnerException.Message);
         }
         catch (Exception ex)
         {
-          LogException(ex.Message);
+            LogException(ex.Message);
         }
       }).ConfigureAwait(false);
 #pragma warning restore 4014


### PR DESCRIPTION
The following behavior was observed when using an Alpha 100 as the host GPS.

Issue:
1. Add collar to host GPS by using the track code.
2. Host GPS initiates packet communication using "Dog" as a placeholder name while waiting for the user to edit the text name of the collar on the host GPS device.
3. Tracker console gracefully handles the collar name changing, but this leaves a hanging reference on the TOPO server to a "{Callsign}-Dog" that is no longer receiving updates from the tracker software once the user updates the collar name on the host GPS.

This change proposes that we internally track collars as usual, but we skip pushing to the TOPO endpoint if the identifier is default ("Dog").