### PR TITLE
QoL Enhancements

### DIFF
--- a/TrackerConsole/D1100TrackedAsset.cs
+++ b/TrackerConsole/D1100TrackedAsset.cs
@@ -134,28 +134,31 @@ namespace TrackerConsole
     }
   }
 
-public enum AssetColor : uint
-{
-clr_black = 0,
-clr_dark_red = 1,
-clr_dark_green = 2,
-clr_dark_yellow = 3,
-clr_dark_blue = 4,
-clr_dark_magenta = 5,
-clr_dark_cyan = 6,
-clr_light_gray = 7,
-clr_dark_gray = 8,
-clr_red = 9,
-clr_green = 10,
-clr_yellow = 11,
-clr_blue = 12,
-clr_magenta = 13,
-clr_cyan = 14,
-clr_white = 15,
-clr_light_blue = 16,
-clr_transparent = 17,
-clr_default_color = 255
-};
+  /// <summary>
+  /// Garmin Defined Colors
+  /// </summary>
+  public enum AssetColor : uint
+  {
+    clr_black = 0,
+    clr_dark_red = 1,
+    clr_dark_green = 2,
+    clr_dark_yellow = 3,
+    clr_dark_blue = 4,
+    clr_dark_magenta = 5,
+    clr_dark_cyan = 6,
+    clr_light_gray = 7,
+    clr_dark_gray = 8,
+    clr_red = 9,
+    clr_green = 10,
+    clr_yellow = 11,
+    clr_blue = 12,
+    clr_magenta = 13,
+    clr_cyan = 14,
+    clr_white = 15,
+    clr_light_blue = 16,
+    clr_transparent = 17,
+    clr_default_color = 255
+  };
 public enum SymbolType : ushort
   {
     /*---------------------------------------------------------------

--- a/TrackerConsole/D1100TrackedAsset.cs
+++ b/TrackerConsole/D1100TrackedAsset.cs
@@ -30,11 +30,11 @@ namespace TrackerConsole
   [Flags]
   public enum StatusFlags : uint
   {
-    LowBattery = 1 << 12,
-    GpsLost = 1 << 13,
-    CommsLost = 1 << 14,
-    MessageReceived = 1 << 15,
-    AssetRemoved = 1 << 16
+    LowBattery = 1,
+    GpsLost = 1 << 1,
+    CommsLost = 1 << 2,
+    MessageReceived = 1 << 3,
+    AssetRemoved = 1 << 4
   }
 
   public enum DogStatus
@@ -98,7 +98,7 @@ namespace TrackerConsole
       DogStatus = (DogStatus)(status & 0x0f);
       Platform = (PlatformType)((status >> 4) & 0x1f);
       TrackerType = (TrackerType)((status >> 8) & 0x07);
-      StatusFlags = (StatusFlags)((status >> 11) & 0x1f);
+      StatusFlags = (StatusFlags)(status >> 12);
       
       Symbol = (SymbolType)BitConverter.ToUInt16(buffer, offset);
       offset += 2;
@@ -115,7 +115,7 @@ namespace TrackerConsole
       Index = buffer[offset++];
 
       StringBuilder sb = new StringBuilder();
-      for (int i=0;i<37;i++)
+      for (int i=0;i<14;i++)
       {
         if (buffer[offset + i] == 0) break;
         sb.Append((char)buffer[offset + i]);
@@ -134,7 +134,29 @@ namespace TrackerConsole
     }
   }
 
-  public enum SymbolType : ushort
+public enum AssetColor : uint
+{
+clr_black = 0,
+clr_dark_red = 1,
+clr_dark_green = 2,
+clr_dark_yellow = 3,
+clr_dark_blue = 4,
+clr_dark_magenta = 5,
+clr_dark_cyan = 6,
+clr_light_gray = 7,
+clr_dark_gray = 8,
+clr_red = 9,
+clr_green = 10,
+clr_yellow = 11,
+clr_blue = 12,
+clr_magenta = 13,
+clr_cyan = 14,
+clr_white = 15,
+clr_light_blue = 16,
+clr_transparent = 17,
+clr_default_color = 255
+};
+public enum SymbolType : ushort
   {
     /*---------------------------------------------------------------
     Marine symbols

--- a/TrackerConsole/Program.cs
+++ b/TrackerConsole/Program.cs
@@ -23,7 +23,27 @@ namespace TrackerConsole
   class Program
   {
     static string callsign = null;
-
+        private static Dictionary<AssetColor, ConsoleColor> _colorMap = new Dictionary<AssetColor, ConsoleColor>() {
+            { AssetColor.clr_black, ConsoleColor.Black},
+            { AssetColor.clr_dark_red, ConsoleColor.DarkRed },
+            { AssetColor.clr_dark_green, ConsoleColor.DarkGreen },
+            { AssetColor.clr_dark_yellow , ConsoleColor.DarkYellow},
+            { AssetColor.clr_dark_blue, ConsoleColor.DarkBlue},
+            { AssetColor.clr_dark_magenta , ConsoleColor.DarkMagenta},
+            { AssetColor.clr_dark_cyan , ConsoleColor.DarkCyan},
+            { AssetColor.clr_light_gray , ConsoleColor.Gray},
+            { AssetColor.clr_dark_gray , ConsoleColor.DarkGray},
+            { AssetColor.clr_red , ConsoleColor.Red},
+            { AssetColor.clr_green , ConsoleColor.Green},
+            { AssetColor.clr_yellow , ConsoleColor.Yellow},
+            { AssetColor.clr_blue , ConsoleColor.Blue},
+            { AssetColor.clr_magenta , ConsoleColor.Magenta},
+            { AssetColor.clr_cyan , ConsoleColor.Cyan},
+            { AssetColor.clr_white , ConsoleColor.White},
+            { AssetColor.clr_light_blue , ConsoleColor.Cyan},
+            { AssetColor.clr_transparent , ConsoleColor.White},
+            { AssetColor.clr_default_color, ConsoleColor.White},
+        };  
     static void Main(string[] args)
     {
       ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
@@ -53,7 +73,7 @@ namespace TrackerConsole
     readonly HttpClient _web = new HttpClient();
     readonly string[] _errors = new string[5];
     int errorIndex = 0;
-    Dictionary<string, D1100TrackedAsset> latest = new Dictionary<string, D1100TrackedAsset>();
+    Dictionary<byte, D1100TrackedAsset> latest = new Dictionary<byte, D1100TrackedAsset>();
     object syncLock = new object();
 
     public Program(string server)
@@ -142,17 +162,29 @@ namespace TrackerConsole
       }
 
       _writer.WriteLine(JsonConvert.SerializeObject(entry));
+
       lock (syncLock)
       {
-        if (latest.ContainsKey(entry.Identifier))
-        {
-          latest[entry.Identifier] = entry;
-        }
-        else
-        {
-          latest.Add(entry.Identifier, entry);
-        }
+                if (entry.StatusFlags.HasFlag(StatusFlags.AssetRemoved) && latest.ContainsKey(entry.Index))
+                {
+                    latest.Remove(entry.Index);
+                    Console.Clear();
+                }
+                else
+                {
+
+                    if (latest.ContainsKey(entry.Index))
+                    {
+
+                        latest[entry.Index] = entry;
+                    }
+                    else
+                    {
+                        latest.Add(entry.Index, entry);
+                    }
+                }
       }
+      
 #pragma warning disable 4014
       Task.Run(async () =>
       {
@@ -174,7 +206,7 @@ namespace TrackerConsole
         }
       }).ConfigureAwait(false);
 #pragma warning restore 4014
-
+      
       Print();
     }
 
@@ -206,7 +238,7 @@ namespace TrackerConsole
         WriteLine(string.Empty);
         foreach (var p in latest.Keys.OrderBy(f => f).Select(f => latest[f]))
         {
-          Console.ForegroundColor = ConsoleColor.White;
+          Console.ForegroundColor = _colorMap[(AssetColor) p.Color];
           string id = p.Identifier.PadRight(4);
           Console.Write(id);
           Console.ForegroundColor = ConsoleColor.Gray;

--- a/TrackerConsole/Program.cs
+++ b/TrackerConsole/Program.cs
@@ -165,7 +165,6 @@ namespace TrackerConsole
       }
 
       _writer.WriteLine(JsonConvert.SerializeObject(entry));
-
       lock (syncLock)
       {
         if (entry.StatusFlags.HasFlag(StatusFlags.AssetRemoved) && latest.ContainsKey(entry.Index))
@@ -208,7 +207,7 @@ namespace TrackerConsole
         }
       }).ConfigureAwait(false);
 #pragma warning restore 4014
-      
+
       Print();
     }
 

--- a/TrackerConsole/Program.cs
+++ b/TrackerConsole/Program.cs
@@ -23,27 +23,30 @@ namespace TrackerConsole
   class Program
   {
     static string callsign = null;
-        private static Dictionary<AssetColor, ConsoleColor> _colorMap = new Dictionary<AssetColor, ConsoleColor>() {
-            { AssetColor.clr_black, ConsoleColor.Black},
-            { AssetColor.clr_dark_red, ConsoleColor.DarkRed },
-            { AssetColor.clr_dark_green, ConsoleColor.DarkGreen },
-            { AssetColor.clr_dark_yellow , ConsoleColor.DarkYellow},
-            { AssetColor.clr_dark_blue, ConsoleColor.DarkBlue},
-            { AssetColor.clr_dark_magenta , ConsoleColor.DarkMagenta},
-            { AssetColor.clr_dark_cyan , ConsoleColor.DarkCyan},
-            { AssetColor.clr_light_gray , ConsoleColor.Gray},
-            { AssetColor.clr_dark_gray , ConsoleColor.DarkGray},
-            { AssetColor.clr_red , ConsoleColor.Red},
-            { AssetColor.clr_green , ConsoleColor.Green},
-            { AssetColor.clr_yellow , ConsoleColor.Yellow},
-            { AssetColor.clr_blue , ConsoleColor.Blue},
-            { AssetColor.clr_magenta , ConsoleColor.Magenta},
-            { AssetColor.clr_cyan , ConsoleColor.Cyan},
-            { AssetColor.clr_white , ConsoleColor.White},
-            { AssetColor.clr_light_blue , ConsoleColor.Cyan},
-            { AssetColor.clr_transparent , ConsoleColor.White},
-            { AssetColor.clr_default_color, ConsoleColor.White},
-        };  
+
+    // Static mapping of Garmin defined colors to ConsoleColor.
+    private static Dictionary<AssetColor, ConsoleColor> _colorMap = new Dictionary<AssetColor, ConsoleColor>() {
+      { AssetColor.clr_black, ConsoleColor.Black},
+      { AssetColor.clr_dark_red, ConsoleColor.DarkRed },
+      { AssetColor.clr_dark_green, ConsoleColor.DarkGreen },
+      { AssetColor.clr_dark_yellow , ConsoleColor.DarkYellow},
+      { AssetColor.clr_dark_blue, ConsoleColor.DarkBlue},
+      { AssetColor.clr_dark_magenta , ConsoleColor.DarkMagenta},
+      { AssetColor.clr_dark_cyan , ConsoleColor.DarkCyan},
+      { AssetColor.clr_light_gray , ConsoleColor.Gray},
+      { AssetColor.clr_dark_gray , ConsoleColor.DarkGray},
+      { AssetColor.clr_red , ConsoleColor.Red},
+      { AssetColor.clr_green , ConsoleColor.Green},
+      { AssetColor.clr_yellow , ConsoleColor.Yellow},
+      { AssetColor.clr_blue , ConsoleColor.Blue},
+      { AssetColor.clr_magenta , ConsoleColor.Magenta},
+      { AssetColor.clr_cyan , ConsoleColor.Cyan},
+      { AssetColor.clr_white , ConsoleColor.White},
+      { AssetColor.clr_light_blue , ConsoleColor.Cyan},
+      { AssetColor.clr_transparent , ConsoleColor.White},
+      { AssetColor.clr_default_color, ConsoleColor.White},
+    };  
+
     static void Main(string[] args)
     {
       ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
@@ -165,24 +168,23 @@ namespace TrackerConsole
 
       lock (syncLock)
       {
-                if (entry.StatusFlags.HasFlag(StatusFlags.AssetRemoved) && latest.ContainsKey(entry.Index))
-                {
-                    latest.Remove(entry.Index);
-                    Console.Clear();
-                }
-                else
-                {
-
-                    if (latest.ContainsKey(entry.Index))
-                    {
-
-                        latest[entry.Index] = entry;
-                    }
-                    else
-                    {
-                        latest.Add(entry.Index, entry);
-                    }
-                }
+        if (entry.StatusFlags.HasFlag(StatusFlags.AssetRemoved) && latest.ContainsKey(entry.Index))
+        {
+          latest.Remove(entry.Index);
+          // Force console redraw since we don't support manually clearing a specific dog in the console.
+          Console.Clear();
+        }
+        else
+        {
+          if (latest.ContainsKey(entry.Index))
+          {
+            latest[entry.Index] = entry;
+          }
+          else
+          {
+            latest.Add(entry.Index, entry);
+          }
+        }
       }
       
 #pragma warning disable 4014


### PR DESCRIPTION
This change aims to address a couple small issues.

StatusFlags:

According to the PDF in this repo, the current mechanism to parse bitflags for the StatusFlags enum isn't functional. This change re-indexes the bit flags to be bits 1-5 and removes the & operator since we can just shift right and parse the uint. This new mechanism will stop working if garmin decides to add data to currently unused 16 LSB bits.

Identifier String:
I went ahead and scoped the byte reads for the identifier string to only look at the first 14 bytes of the identifier string in the packet since 14 characters is the max size of a dog name that garmin devices allow. I've seen a rare behavior where the 15th character wasn't a 0x00 byte and caused the dog name to change. Garmin spec doesn't guarantee that bytes outside the max character length will be zero'd or null terminated, so it might be safest to not look at the packet further than is possible. This is subject to change if Garmin changes the max dog string length on GPS devices.

Cache latest assets based on Index instead of Identifier:
Garmin spec says that the index byte can be used to locally cache an asset. This has advantages over using the identifier string as the key in the "latest" map since updating dog names won't leave an orphaned entry with the old name in the map. Note that asset indices can be recycled within a session if the host device receives an "AssetRemoved" status flag, so I added a manual removal from the latest map if a collar is explicitly deleted from the host GPS. I had to add a console clear to support this since the current Print() method doesn't currently support dynamic removal of entries once they have begun printing.

Console Color:
I added a static mapping of received garmin collar color code : ConsoleColor enum. This allows for dog names in the console to have the same color as their track on the GPS unit. This is the "cutest" change in this PR and I'm fine tucking the functionality behind a cmd line arg or removing it entirely.